### PR TITLE
Add verseBackgroundColor parameter to PageviewQuran widget

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -87,26 +87,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -135,10 +135,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -153,7 +153,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.0.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -203,18 +203,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:

--- a/lib/src/quran_pageview.dart
+++ b/lib/src/quran_pageview.dart
@@ -32,6 +32,11 @@ class PageviewQuran extends StatefulWidget {
   /// Background color for the whole page container.
   final Color pageBackgroundColor;
 
+  /// Optional callback to get background color for individual verses.
+  /// Returns a Color for the verse, or null for no background color.
+  /// Useful for highlighting selected verses.
+  final Color? Function(int surahNumber, int verseNumber)? verseBackgroundColor;
+
   /// Long-press callbacks that include the pressed verse info.
   final void Function(int surahNumber, int verseNumber)? onLongPress;
   final void Function(int surahNumber, int verseNumber)? onLongPressUp;
@@ -53,6 +58,7 @@ class PageviewQuran extends StatefulWidget {
     this.h = 1,
     this.textColor = const Color(0xFF000000),
     this.pageBackgroundColor = const Color(0xFFFFFFFF),
+    this.verseBackgroundColor,
     this.onLongPress,
     this.onLongPressUp,
     this.onLongPressCancel,
@@ -106,6 +112,7 @@ class _PageviewQuranState extends State<PageviewQuran> {
               pageNumber: pageNumber,
               fontSize: widget.fontSize,
               textColor: widget.textColor,
+              verseBackgroundColor: widget.verseBackgroundColor,
               onLongPress: widget.onLongPress,
               onLongPressUp: widget.onLongPressUp,
               onLongPressCancel: widget.onLongPressCancel,
@@ -124,6 +131,7 @@ class _PageContent extends StatelessWidget {
   final int pageNumber;
   final double? fontSize;
   final Color textColor;
+  final Color? Function(int surahNumber, int verseNumber)? verseBackgroundColor;
   final void Function(int surahNumber, int verseNumber)? onLongPress;
   final void Function(int surahNumber, int verseNumber)? onLongPressUp;
   final void Function(int surahNumber, int verseNumber)? onLongPressCancel;
@@ -145,6 +153,7 @@ class _PageContent extends StatelessWidget {
     required this.pageNumber,
     required this.fontSize,
     required this.textColor,
+    this.verseBackgroundColor,
     required this.onLongPress,
     required this.onLongPressUp,
     required this.onLongPressCancel,
@@ -176,24 +185,24 @@ class _PageContent extends StatelessWidget {
         if (v == start && v == 1) {
           verseSpans.add(WidgetSpan(child: HeaderWidget(suraNumber: surah)));
           if (pageNumber != 1 && pageNumber != 187) {
-            if(surah != 97){
-             verseSpans.add(
-              TextSpan(
-                text: " ﱁ  ﱂﱃﱄ\n",
-                style: TextStyle(
-                  fontFamily: "QCF_P001",
-                  package: 'qcf_quran',
-                  fontSize: getScreenType(context) == ScreenType.large
-                      ? 13.2 / sp
-                      : 24 / sp,
-                  color: Colors.black,
-                ),
-              ),
-            );
-            }else
-          {  verseSpans.add(
+            if (surah != 97) {
+              verseSpans.add(
                 TextSpan(
-                text:  "齃𧻓𥳐龎\n" ,
+                  text: " ﱁ  ﱂﱃﱄ\n",
+                  style: TextStyle(
+                    fontFamily: "QCF_P001",
+                    package: 'qcf_quran',
+                    fontSize: getScreenType(context) == ScreenType.large
+                        ? 13.2 / sp
+                        : 24 / sp,
+                    color: Colors.black,
+                  ),
+                ),
+              );
+            } else {
+              verseSpans.add(
+                TextSpan(
+                  text: "齃𧻓𥳐龎\n",
                   style: TextStyle(
                     fontFamily: "QCF_BSML",
                     package: 'qcf_quran',
@@ -203,7 +212,8 @@ class _PageContent extends StatelessWidget {
                     color: Colors.black,
                   ),
                 ),
-              ); }
+              );
+            }
           }
         }
         final spanRecognizer = LongPressGestureRecognizer();
@@ -214,12 +224,17 @@ class _PageContent extends StatelessWidget {
         spanRecognizer.onLongPressEnd = (LongPressEndDetails d) =>
             onLongPressCancel?.call(surah, v);
 
+        final verseBgColor = verseBackgroundColor?.call(surah, v);
+
         verseSpans.add(
           TextSpan(
-            text:v==ranges[0]['start']        ?  "${getVerseQCF(surah, v, verseEndSymbol: false).substring(0, 1)}\u200A${getVerseQCF(surah, v, verseEndSymbol: false).substring(1, getVerseQCF(surah, v, verseEndSymbol: false).length )}"
-        : getVerseQCF(surah, v, verseEndSymbol: false
-          ),
+            text: v == ranges[0]['start']
+                ? "${getVerseQCF(surah, v, verseEndSymbol: false).substring(0, 1)}\u200A${getVerseQCF(surah, v, verseEndSymbol: false).substring(1, getVerseQCF(surah, v, verseEndSymbol: false).length)}"
+                : getVerseQCF(surah, v, verseEndSymbol: false),
             recognizer: spanRecognizer,
+            style: verseBgColor != null
+                ? TextStyle(backgroundColor: verseBgColor)
+                : null,
             children: [
               TextSpan(
                 text: getVerseNumberQCF(surah, v),
@@ -228,6 +243,7 @@ class _PageContent extends StatelessWidget {
                   package: 'qcf_quran',
                   color: Colors.brown,
                   height: 1.35 / h,
+                  backgroundColor: verseBgColor,
                 ),
               ),
             ],


### PR DESCRIPTION
## ✨ Add `verseBackgroundColor` parameter to `PageviewQuran` widget

### 📋 Description

Implements the missing `verseBackgroundColor` parameter for `PageviewQuran`, which was documented but not implemented. This enables per-verse background colors, useful for highlighting selected verses.

### 🐛 Problem

The `verseBackgroundColor` parameter was listed in the documentation but missing from the implementation, causing compilation errors when used.

**Issue:** Developers following the official docs expected `verseBackgroundColor` but it wasn't available in the constructor.

### ✅ Solution

Added `verseBackgroundColor` as an optional callback parameter that allows customizing the background color of individual verses. This enables developers to:

- Highlight selected verses  
- Provide visual feedback for user interactions  
- Customize verse appearance based on app logic  

### 🔧 Changes Made

1. **Added `verseBackgroundColor` parameter to `PageviewQuran` class:**
   - Type: `Color? Function(int surahNumber, int verseNumber)?`
   - Optional callback that returns a `Color` for specific verses or `null` for no background
   - Supports per-verse customization for highlighting selected verses

2. **Implemented background color application:**
   - Applied to both verse text and verse number spans
   - Uses `TextStyle.backgroundColor` for proper rendering
   - Background color is applied conditionally based on callback return value

3. **Passed parameter through widget hierarchy:**
   - Added to `PageviewQuran` constructor
   - Passed to `_PageContent` widget
   - Applied during verse rendering in the build method

### 💻 Usage Example

#### **Basic Usage**

```dart
PageviewQuran(
  initialPageNumber: 1,
  textColor: Colors.black,
  verseBackgroundColor: (surah, verse) {
    // Highlight specific verses (e.g., selected verse)
    if (surah == 2 && verse == 255) {
      return Colors.yellow.withOpacity(0.3);
    }
    return null; // No background for other verses
  },
);
```

## Screenshots 📸 :

| First Screenshot | Second Screenshot |
| ------------- | -------------|
| <img src= "https://github.com/user-attachments/assets/63f083f7-2c61-463a-be87-45c30f587f8a" width="187.5" height="406"> | <img src= "https://github.com/user-attachments/assets/96b79894-b167-411f-a9ad-3b00457d09d0" width="187.5" height="406"> |
